### PR TITLE
Popup fix

### DIFF
--- a/src/main/java/bejeweled/Main.java
+++ b/src/main/java/bejeweled/Main.java
@@ -329,6 +329,7 @@ public final class Main extends Application {
 		Popup popup = Popups.gameOverPopup(score);
 		popup.show(stage);
 		root.setDisable(true);
+		scene.getGameLogic().setDisabled(true);
 		Button confirm = (Button) popup.getContent().get(2);
 		confirm.setOnAction(new EventHandler<ActionEvent>() {
 

--- a/src/main/java/bejeweled/Main.java
+++ b/src/main/java/bejeweled/Main.java
@@ -258,7 +258,16 @@ public final class Main extends Application {
 					if (Sounds.getInstance().backgroundSoundPlaying()) {
 						Sounds.getInstance().stopBackgroundSound();
 					} else {
+						Sounds.getInstance().stopRickRoll();
 						Sounds.getInstance().playBackgroundSound();
+					}
+				}
+				if(e.getCode() == KeyCode.R) {
+					if (Sounds.getInstance().rickrollSoundPlaying()) {
+						Sounds.getInstance().stopRickRoll();
+					} else {
+						Sounds.getInstance().playRickRoll();
+						Sounds.getInstance().stopBackgroundSound();
 					}
 				}
 			}

--- a/src/main/java/bejeweled/Main.java
+++ b/src/main/java/bejeweled/Main.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Random;
+
 import bejeweled.board.Board;
+
 import java.util.Scanner;
+
 import bejeweled.board.Gem;
 import bejeweled.board.GemType;
 import bejeweled.game.GameLogic;
@@ -30,6 +33,8 @@ import javafx.scene.control.Label;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
@@ -228,6 +233,7 @@ public final class Main extends Application {
 		imgView.setFitWidth(800);
 
 		root.getChildren().addAll(imgView);
+		
 		Sounds.getInstance().playBackgroundSound();
 		if (savedGame) {
 			loadFile();
@@ -241,6 +247,23 @@ public final class Main extends Application {
 				scene.draw();
 			}
 		}.start();
+		
+		root.setOnKeyReleased(new EventHandler<KeyEvent>() {
+			@Override
+			public void handle(KeyEvent e) {
+				if(e.getCode() == KeyCode.ESCAPE || e.getCode() == KeyCode.P) {
+					scene.showPopup(stage, root);
+				} 
+				if(e.getCode() == KeyCode.M) {
+					if (Sounds.getInstance().backgroundSoundPlaying()) {
+						Sounds.getInstance().stopBackgroundSound();
+					} else {
+						Sounds.getInstance().playBackgroundSound();
+					}
+				}
+			}
+		});
+		
 		stage.setScene(scene);
 	}
 

--- a/src/main/java/bejeweled/Sounds.java
+++ b/src/main/java/bejeweled/Sounds.java
@@ -16,6 +16,7 @@ public final class Sounds {
 	private static AudioClip errorSound;
 	private static AudioClip gameOverSound;
 	private static AudioClip shoutOutSound;
+	private static AudioClip rickrollSound;
 	private static Sounds sounds = null;
 
 	/**
@@ -31,6 +32,7 @@ public final class Sounds {
 		errorSound = new AudioClip(new File("src/main/java/Sounds/error.wav").toURI().toString());
 		gameOverSound = new AudioClip(new File("src/main/java/Sounds/gameover.wav").toURI().toString());
 		shoutOutSound = new AudioClip(new File("src/main/java/Sounds/perfect.wav").toURI().toString());
+		rickrollSound = new AudioClip(new File("src/main/java/Sounds/NeverGonnaGiveYouUp.wav").toURI().toString());
 	}
 
 	// This method is part of the singleton pattern
@@ -68,6 +70,20 @@ public final class Sounds {
 	public void stopBackgroundSound() {
 		backgroundSound.stop();
 	}
+	
+	/**
+	 * Plays the background sound effect.
+	 */
+	public void playRickRoll() {
+		rickrollSound.play();
+	}
+
+	/**
+	 * Stops the background sound effect.
+	 */
+	public void stopRickRoll() {
+		rickrollSound.stop();
+	}
 
 	/**
 	 * Plays the error sound effect.
@@ -95,5 +111,12 @@ public final class Sounds {
 	 */
 	public boolean backgroundSoundPlaying() {
 		return backgroundSound.isPlaying();
+	}
+	
+	/**
+	 * @return true if backgroundSound is playing already.
+	 */
+	public boolean rickrollSoundPlaying() {
+		return rickrollSound.isPlaying();
 	}
 }

--- a/src/main/java/bejeweled/game/GameLogic.java
+++ b/src/main/java/bejeweled/game/GameLogic.java
@@ -31,6 +31,7 @@ import bejeweled.state.Time;
  */
 public final class GameLogic{
 	private boolean isanimating = false;
+	private boolean disabled;
 	private Board board;
 	private static Time time;
 	private static Score score;
@@ -80,7 +81,7 @@ public final class GameLogic{
 	 */
 	public void handleMouseClicked(final int row, final int col) {
 		//we won't handle mouseclicks while an animation is running
-		if(isanimating) {
+		if(isanimating || disabled) {
 			return;
 		}
 		if(board.handleMouseClickedBoard(row,col)){
@@ -226,6 +227,14 @@ public final class GameLogic{
 
 	public Difficulties getDif() {
 		return dif;
+	}
+	
+	public void setDisabled(boolean disabled) {
+		this.disabled = disabled;
+	}
+	
+	public boolean getDisabled() {
+		return disabled;
 	}
 }
 	

--- a/src/main/java/bejeweled/game/GameScene.java
+++ b/src/main/java/bejeweled/game/GameScene.java
@@ -16,11 +16,13 @@ import javafx.scene.shape.Circle;
 import javafx.scene.text.Font;
 import javafx.stage.Popup;
 import javafx.stage.Stage;
+
 import java.util.Observable;
 import java.util.Observer;
 
 import bejeweled.Difficulties;
 import bejeweled.Main;
+import bejeweled.Sounds;
 import bejeweled.board.Gem;
 import bejeweled.gui.Buttons;
 import bejeweled.gui.Popups;
@@ -65,11 +67,7 @@ public final class GameScene extends Scene implements Observer {
 		pauseButton.setOnAction(new EventHandler<ActionEvent>() {
 			@Override
 			public void handle(ActionEvent e) {
-				Main.getTimeline().pause();
-				Popup popup = Popups.pausePopup(root, gamelogic);
-				popup.show(stage);
-				root.setDisable(true);
-
+				showPopup(stage, root);
 			}
 		});
 
@@ -153,6 +151,14 @@ public final class GameScene extends Scene implements Observer {
 		score.setText(scoreObject.getScore()+"");
 	}
 	
-	
+	public void showPopup(Stage stage, Group root) {
+		if(Sounds.getInstance().backgroundSoundPlaying()) {
+			Popup popup = Popups.pausePopup(root, gamelogic, true);
+			popup.show(stage);
+		} else {
+			Popup popup = Popups.pausePopup(root, gamelogic, false);
+			popup.show(stage);
+		}
+	}
 
 }

--- a/src/main/java/bejeweled/game/GameScene.java
+++ b/src/main/java/bejeweled/game/GameScene.java
@@ -152,7 +152,7 @@ public final class GameScene extends Scene implements Observer {
 	}
 	
 	public void showPopup(Stage stage, Group root) {
-		if(Sounds.getInstance().backgroundSoundPlaying()) {
+		if(Sounds.getInstance().backgroundSoundPlaying() || Sounds.getInstance().rickrollSoundPlaying()) {
 			Popup popup = Popups.pausePopup(root, gamelogic, true);
 			popup.show(stage);
 		} else {

--- a/src/main/java/bejeweled/gui/Popups.java
+++ b/src/main/java/bejeweled/gui/Popups.java
@@ -83,6 +83,14 @@ public class Popups {
 			public void handle(WindowEvent e) {
 				root.setDisable(true);
 				Main.getTimeline().stop();
+				gamelogic.setDisabled(true);
+			}
+		});
+		
+		popup.setOnHiding(new EventHandler<WindowEvent>() {
+			@Override
+			public void handle(WindowEvent e) {
+				gamelogic.setDisabled(false);
 			}
 		});
 

--- a/src/main/java/bejeweled/gui/Popups.java
+++ b/src/main/java/bejeweled/gui/Popups.java
@@ -32,6 +32,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.stage.Popup;
+import javafx.stage.WindowEvent;
 
 /**
  * A class dedicated to making popups.
@@ -49,7 +50,7 @@ public class Popups {
 	 *            - The gamescene which needs to be reenabled.
 	 * @return - The pause menu.
 	 */
-	public static Popup pausePopup(Group root, GameLogic gamelogic) {
+	public static Popup pausePopup(Group root, GameLogic gamelogic, boolean music) {
 		Popup popup = new Popup();
 		popup.setWidth(330);
 		popup.setHeight(450);
@@ -72,7 +73,18 @@ public class Popups {
 		mute.setEndX(170);
 		mute.setEndY(220);
 		mute.setStrokeWidth(1.0);
-		mute.setVisible(false);
+		if(music) {
+			mute.setVisible(false);
+		}
+		
+		popup.setHideOnEscape(false);
+		popup.setOnShowing(new EventHandler<WindowEvent>() {
+			@Override
+			public void handle(WindowEvent e) {
+				root.setDisable(true);
+				Main.getTimeline().stop();
+			}
+		});
 
 		musicButton.setOnAction(new EventHandler<ActionEvent>() {
 			@Override
@@ -119,17 +131,17 @@ public class Popups {
 
 		Button save = Buttons.pauseMenuButton("Save");
 		
-		popup.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
+		popup.addEventHandler(KeyEvent.KEY_RELEASED, new EventHandler<KeyEvent>() {
 			@Override
 			public void handle(KeyEvent e) {
-				if(e.getCode() == KeyCode.ESCAPE) {
+				if(e.getCode() == KeyCode.ESCAPE || e.getCode() == KeyCode.P) {
 					root.setDisable(false);
 					popup.hide();
 					Main.getTimeline().play();
 				}
 			}
-		});
-
+		});	
+		
 		/*
 		 * Pressing the save button will save the current state of the game to a
 		 * savefile.

--- a/src/main/java/bejeweled/gui/Popups.java
+++ b/src/main/java/bejeweled/gui/Popups.java
@@ -100,6 +100,10 @@ public class Popups {
 				if (Sounds.getInstance().backgroundSoundPlaying()) {
 					Sounds.getInstance().stopBackgroundSound();
 					mute.setVisible(true);
+				} else if(Sounds.getInstance().rickrollSoundPlaying()) {
+					Sounds.getInstance().stopRickRoll();
+					System.out.println("test");
+					mute.setVisible(true);
 				} else {
 					Sounds.getInstance().playBackgroundSound();
 					mute.setVisible(false);

--- a/src/main/java/bejeweled/gui/Popups.java
+++ b/src/main/java/bejeweled/gui/Popups.java
@@ -18,6 +18,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -116,6 +118,17 @@ public class Popups {
 		});
 
 		Button save = Buttons.pauseMenuButton("Save");
+		
+		popup.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
+			@Override
+			public void handle(KeyEvent e) {
+				if(e.getCode() == KeyCode.ESCAPE) {
+					root.setDisable(false);
+					popup.hide();
+					Main.getTimeline().play();
+				}
+			}
+		});
 
 		/*
 		 * Pressing the save button will save the current state of the game to a

--- a/src/main/java/bejeweled/state/Score.java
+++ b/src/main/java/bejeweled/state/Score.java
@@ -26,7 +26,7 @@ public final class Score extends Observable {
 	 */
 	public void updateScore(int gems) {
 		score += gems*scorePerGem;
-		int goodscore = 30;
+		int goodscore = 4 * scorePerGem;
 		if (gems*scorePerGem > goodscore) {
 			Main.shoutOut();
 		}


### PR DESCRIPTION
Added: button handlers on the bejeweled playing field screen.
            You can now pause the game with the "esc" and "P" keys and mute the background music
            with the"M" key. The mute icon will show a muted icon or a music icon depending on the
            background music.
            The keys work on key release.
Fixed: User can no longer continue to play when the game is over. Added a disabled boolean in
           gamelogic.